### PR TITLE
fix issue with strpos

### DIFF
--- a/src/ErrorHandler.php
+++ b/src/ErrorHandler.php
@@ -343,7 +343,7 @@ class ErrorHandler implements ErrorHandlerInterface
         $result = [];
 
         for ($i = 0; $i < $length; $i++) {
-            $result[] = $space."#".$i.substr($trace[$i], strpos($trace[$i], " "));  // replace '#someNum' with '#$i', set the right ordering
+            $result[] = $space."#".$i.substr($trace[$i], strpos($trace[$i], " ") ?: 0);  // replace '#someNum' with '#$i', set the right ordering
         }
 
         $trace = $level !== 0


### PR DESCRIPTION
as `strpos` returns `int|false` but `substr` requires `int|null` we convert that `false` to `0`