### PR TITLE
fix issue with throwable code

### DIFF
--- a/src/ErrorHandler.php
+++ b/src/ErrorHandler.php
@@ -195,7 +195,7 @@ class ErrorHandler implements ErrorHandlerInterface
             $t->getMessage(),
             $t->getFile(),
             $t->getLine(),
-            $t->getCode(),
+            intval($t->getCode()),
             $errMessage
         );
     }


### PR DESCRIPTION
as `getCode` from a throwable may return a string as well we need to convert the data to an int